### PR TITLE
Define globalEnv to be used instead of use all

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -35,9 +35,7 @@
       "exposeByDefault": true
     }
   ],
-  "globalEnvs": {
-    "all": true
-  },
+  "globalEnvs": [{ "envs": ["DOMAIN"], "services": ["pocket"] }],
   "backup": [
     {
       "name": "keyfile",


### PR DESCRIPTION
Define the global Env to be used by the dappnode package instead of use all of them