### PR TITLE
Bump upstream BETA-0.10.2 and change package/container registry.

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket.dnp.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "RC-0.9.2",
+  "upstreamVersion": "BETA-0.10.2",
   "upstreamRepo": "pokt-network/pocket-core",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Web3 Infrastructure The Right Way.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: pocket
       args:
-        UPSTREAM_VERSION: RC-0.9.2
+        UPSTREAM_VERSION: BETA-0.10.2
     restart: unless-stopped
     volumes:
       - "pocket-mainnet:/home/app/.pocket/"

--- a/pocket/Dockerfile
+++ b/pocket/Dockerfile
@@ -9,8 +9,8 @@ COPY ui /app/ui
 WORKDIR /app/ui
 RUN yarn && yarn build
 
-
-FROM poktnetwork/pocket-core:${UPSTREAM_VERSION}
+#Starting with version BETA-0.10.2 of the v0 Pokt Core, the Docker package registry has been replaced by the Github Container Registry at ghcr.io/pokt-network/pocket-v0:BETA-0.10.2
+FROM ghcr.io/pokt-network/pocket-v0:${UPSTREAM_VERSION}
 
 WORKDIR /home/app/
 


### PR DESCRIPTION
~~FROM poktnetwork/pocket-core:${UPSTREAM_VERSION}~~
#Starting with version BETA-0.10.2 of the v0 Pokt Core, the Docker package registry has been replaced by the Github Container Registry at ghcr.io/pokt-network/pocket-v0:BETA-0.10.2

`FROM ghcr.io/pokt-network/pocket-v0:${UPSTREAM_VERSION}`

Fixes CI and lets the latest beta version be used!
